### PR TITLE
Make sure devutils rspec loader are loaded

### DIFF
--- a/spec/codecs/plain_spec.rb
+++ b/spec/codecs/plain_spec.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-
+require "logstash/devutils/rspec/spec_helper"
 require "logstash/codecs/plain"
 require "logstash/event"
 require "insist"


### PR DESCRIPTION
Make sure the devutils rspec are loaded before any tests are run to make
sure the log4j logger is correclty configured.

Fixes: #3

