### PR TITLE
remove check for LogStash::Event and code cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.6
+  - Code cleanup. See https://github.com/logstash-plugins/logstash-codec-plain/pull/6
+
 ## 3.0.5
   - Update gemspec summary
 

--- a/lib/logstash/codecs/plain.rb
+++ b/lib/logstash/codecs/plain.rb
@@ -24,24 +24,19 @@ class LogStash::Codecs::Plain < LogStash::Codecs::Base
   # This only affects "plain" format logs since json is `UTF-8` already.
   config :charset, :validate => ::Encoding.name_list, :default => "UTF-8"
 
-  public
+  MESSAGE_FIELD = "message".freeze
+
   def register
     @converter = LogStash::Util::Charset.new(@charset)
     @converter.logger = @logger
   end
 
-  public
   def decode(data)
-    yield LogStash::Event.new("message" => @converter.convert(data))
-  end # def decode
+    yield LogStash::Event.new(MESSAGE_FIELD => @converter.convert(data))
+  end
 
-  public
   def encode(event)
-    if event.is_a?(LogStash::Event) and @format
-      @on_event.call(event, event.sprintf(@format))
-    else
-      @on_event.call(event, event.to_s)
-    end
-  end # def encode
-
-end # class LogStash::Codecs::Plain
+    encoded = @format ? event.sprintf(@format) : event.to_s
+    @on_event.call(event, encoded)
+  end
+end

--- a/logstash-codec-plain.gemspec
+++ b/logstash-codec-plain.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-plain'
-  s.version         = '3.0.5'
+  s.version         = '3.0.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads plaintext with no delimiting between events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Per elastic/logstash/issues/8847 - removed check for `LogStash::Event` and code cleanup.