### PR TITLE
Feat: ECS compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.0
+  - Feat: ECS compatibility [#10](https://github.com/logstash-plugins/logstash-codec-plain/pull/10)
+
 ## 3.0.6
   - Code cleanup. See https://github.com/logstash-plugins/logstash-codec-plain/pull/6
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -32,6 +32,7 @@ framing in their transport protocol (such as zeromq, rabbitmq, redis, etc)
 |=======================================================================
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-charset>> |<<string,string>>, one of `["ASCII-8BIT", "UTF-8", "US-ASCII", "Big5", "Big5-HKSCS", "Big5-UAO", "CP949", "Emacs-Mule", "EUC-JP", "EUC-KR", "EUC-TW", "GB2312", "GB18030", "GBK", "ISO-8859-1", "ISO-8859-2", "ISO-8859-3", "ISO-8859-4", "ISO-8859-5", "ISO-8859-6", "ISO-8859-7", "ISO-8859-8", "ISO-8859-9", "ISO-8859-10", "ISO-8859-11", "ISO-8859-13", "ISO-8859-14", "ISO-8859-15", "ISO-8859-16", "KOI8-R", "KOI8-U", "Shift_JIS", "UTF-16BE", "UTF-16LE", "UTF-32BE", "UTF-32LE", "Windows-31J", "Windows-1250", "Windows-1251", "Windows-1252", "IBM437", "IBM737", "IBM775", "CP850", "IBM852", "CP852", "IBM855", "CP855", "IBM857", "IBM860", "IBM861", "IBM862", "IBM863", "IBM864", "IBM865", "IBM866", "IBM869", "Windows-1258", "GB1988", "macCentEuro", "macCroatian", "macCyrillic", "macGreek", "macIceland", "macRoman", "macRomania", "macThai", "macTurkish", "macUkraine", "CP950", "CP951", "IBM037", "stateless-ISO-2022-JP", "eucJP-ms", "CP51932", "EUC-JIS-2004", "GB12345", "ISO-2022-JP", "ISO-2022-JP-2", "CP50220", "CP50221", "Windows-1256", "Windows-1253", "Windows-1255", "Windows-1254", "TIS-620", "Windows-874", "Windows-1257", "MacJapanese", "UTF-7", "UTF8-MAC", "UTF-16", "UTF-32", "UTF8-DoCoMo", "SJIS-DoCoMo", "UTF8-KDDI", "SJIS-KDDI", "ISO-2022-JP-KDDI", "stateless-ISO-2022-JP-KDDI", "UTF8-SoftBank", "SJIS-SoftBank", "BINARY", "CP437", "CP737", "CP775", "IBM850", "CP857", "CP860", "CP861", "CP862", "CP863", "CP864", "CP865", "CP866", "CP869", "CP1258", "Big5-HKSCS:2008", "ebcdic-cp-us", "eucJP", "euc-jp-ms", "EUC-JISX0213", "eucKR", "eucTW", "EUC-CN", "eucCN", "CP936", "ISO2022-JP", "ISO2022-JP2", "ISO8859-1", "ISO8859-2", "ISO8859-3", "ISO8859-4", "ISO8859-5", "ISO8859-6", "CP1256", "ISO8859-7", "CP1253", "ISO8859-8", "CP1255", "ISO8859-9", "CP1254", "ISO8859-10", "ISO8859-11", "CP874", "ISO8859-13", "CP1257", "ISO8859-14", "ISO8859-15", "ISO8859-16", "CP878", "MacJapan", "ASCII", "ANSI_X3.4-1968", "646", "CP65000", "CP65001", "UTF-8-MAC", "UTF-8-HFS", "UCS-2BE", "UCS-4BE", "UCS-4LE", "CP932", "csWindows31J", "SJIS", "PCK", "CP1250", "CP1251", "CP1252", "external", "locale"]`|No
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-format>> |<<string,string>>|No
 |=======================================================================
 
@@ -50,6 +51,19 @@ This setting is useful if your log files are in `Latin-1` (aka `cp1252`)
 or in another character set other than `UTF-8`.
 
 This only affects "plain" format logs since json is `UTF-8` already.
+
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+* Value type is <<string,string>>
+* Supported values are:
+** `disabled`: plugin only sets the `message` field
+** `v1`,`v8`: Elastic Common Schema compliant behavior (`[event][original]` is also added)
+* Default value depends on which version of Logstash is running:
+** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+** Otherwise, the default value is `disabled`
+
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
 
 [id="plugins-{type}s-{plugin}-format"]
 ===== `format` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -23,10 +23,10 @@ include::{include_path}/plugin_header.asciidoc[]
 The "plain" codec is for plain text with no delimiting between events.
 
 This is mainly useful on inputs and outputs that already have a defined
-framing in their transport protocol (such as zeromq, rabbitmq, redis, etc)
+framing in their transport protocol (such as zeromq, rabbitmq, redis, etc).
 
 [id="plugins-{type}s-{plugin}-options"]
-==== Plain Codec Configuration Options
+==== Plain codec configuration options
 
 [cols="<,<,<",options="header",]
 |=======================================================================

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -55,13 +55,13 @@ This only affects "plain" format logs since json is `UTF-8` already.
 [id="plugins-{type}s-{plugin}-ecs_compatibility"]
 ===== `ecs_compatibility`
 
-* Value type is <<string,string>>
-* Supported values are:
-** `disabled`: plugin only sets the `message` field
-** `v1`,`v8`: Elastic Common Schema compliant behavior (`[event][original]` is also added)
-* Default value depends on which version of Logstash is running:
-** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
-** Otherwise, the default value is `disabled`
+  * Value type is <<string,string>>
+  * Supported values are:
+    ** `disabled`: plugin only sets the `message` field
+    ** `v1`,`v8`: Elastic Common Schema compliant behavior (`[event][original]` is also added)
+  * Default value depends on which version of Logstash is running:
+    ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+    ** Otherwise, the default value is `disabled`
 
 Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
 

--- a/logstash-codec-plain.gemspec
+++ b/logstash-codec-plain.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+  s.add_runtime_dependency "logstash-mixin-ecs_compatibility_support", "< 2"
+  s.add_runtime_dependency "logstash-mixin-event_support", "< 2"
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'insist'

--- a/logstash-codec-plain.gemspec
+++ b/logstash-codec-plain.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-plain'
-  s.version         = '3.0.6'
+  s.version         = '3.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads plaintext with no delimiting between events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -27,4 +27,3 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'insist'
 end
-

--- a/logstash-codec-plain.gemspec
+++ b/logstash-codec-plain.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency "logstash-mixin-ecs_compatibility_support", '~> 1.3', '< 2'
-  s.add_runtime_dependency "logstash-mixin-event_support", '< 2'
+  s.add_runtime_dependency "logstash-mixin-ecs_compatibility_support", '~> 1.3'
+  s.add_runtime_dependency "logstash-mixin-event_support", '~> 1.0'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'insist'

--- a/logstash-codec-plain.gemspec
+++ b/logstash-codec-plain.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency "logstash-mixin-ecs_compatibility_support", "< 2"
-  s.add_runtime_dependency "logstash-mixin-event_support", "< 2"
+  s.add_runtime_dependency "logstash-mixin-ecs_compatibility_support", '~> 1.3', '< 2'
+  s.add_runtime_dependency "logstash-mixin-event_support", '< 2'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'insist'


### PR DESCRIPTION
Added `ecs_compatibility` setting since we still want to set `event.original` in ECS mode.

Also, leveraging LS' `new_event` [factory interface](https://github.com/elastic/logstash/issues/13021).